### PR TITLE
Update PMT Metric Producer fcl params for file streams

### DIFF
--- a/standard/EventBuilder_standard.fcl
+++ b/standard/EventBuilder_standard.fcl
@@ -265,6 +265,11 @@ physics: {
       module_type: "PMTMetricProducer"
  
     }
+    pmtmetricproducer_bnbzero: @local::pmtmetricproducer
+    pmtmetricproducer_bnblight: @local::pmtmetricproducer
+    pmtmetricproducer_offbeamzero: @local::pmtmetricproducer
+    pmtmetricproducer_offbeamlight: @local::pmtmetricproducer
+    pmtmetricproducer_crossmuon: @local::pmtmetricproducer
   }
   filters: {
     prescale50: {
@@ -318,11 +323,11 @@ physics: {
 
   softwaretrig: [prescale1, crttriggerproducer, pmtmetricproducer] 
   nustream: [bnbzerobiasfilter, crttriggerproducer, pmtmetricproducer, neutrinostream]
-  bnbzerobias: [bnbzerobiasfilter, crttriggerproducer, pmtmetricproducer] 
-  offbeamzerobias: [offbeamzerobiasfilter, crttriggerproducer, pmtmetricproducer] 
-  bnblight: [bnblightfilter, crttriggerproducer, pmtmetricproducer] 
-  offbeamlight: [offbeamlightfilter, crttriggerproducer, pmtmetricproducer] 
-  crossingmuon: [crossingmuonfilter, crttriggerproducer, pmtmetricproducer] 
+  bnbzerobias: [bnbzerobiasfilter, crttriggerproducer, pmtmetricproducer_bnbzero] 
+  offbeamzerobias: [offbeamzerobiasfilter, crttriggerproducer, pmtmetricproducer_offbeamzero] 
+  bnblight: [bnblightfilter, crttriggerproducer, pmtmetricproducer_bnblight] 
+  offbeamlight: [offbeamlightfilter, crttriggerproducer, pmtmetricproducer_offbeamlight] 
+  crossingmuon: [crossingmuonfilter, crttriggerproducer, pmtmetricproducer_crossmuon] 
   #nscrossingmuon: [nscrossingmuonfilter, crttriggerproducer, pmtmetricproducer] 
   filterfail: ["!crossingmuonfilter", "!bnbzerobiasfilter", "!offbeamzerobiasfilter", "!bnblightfilter", "!offbeamlightfilter"] 
 
@@ -336,6 +341,12 @@ physics: {
 
   end_paths: [a1, my_output_modules] 
 }
+
+physics.producers.pmtmetricproducer_bnbzero.StreamType: 1
+physics.producers.pmtmetricproducer_bnblight.StreamType: 2
+physics.producers.pmtmetricproducer_offbeamzero.StreamType: 3
+physics.producers.pmtmetricproducer_offbeamlight.StreamType: 4
+physics.producers.pmtmetricproducer_crossmuon.StreamType: 5
 
 source: {
   module_type: ArtdaqInput 

--- a/standard/EventBuilder_standard.fcl
+++ b/standard/EventBuilder_standard.fcl
@@ -362,12 +362,6 @@ physics: {
   end_paths: [a1, my_output_modules] 
 }
 
-physics.producers.pmtmetricproducer_bnbzero.StreamType: 1
-physics.producers.pmtmetricproducer_bnblight.StreamType: 2
-physics.producers.pmtmetricproducer_offbeamzero.StreamType: 3
-physics.producers.pmtmetricproducer_offbeamlight.StreamType: 4
-physics.producers.pmtmetricproducer_crossmuon.StreamType: 5
-
 source: {
   module_type: ArtdaqInput 
   waiting_time: 2500000 

--- a/standard/EventBuilder_standard.fcl
+++ b/standard/EventBuilder_standard.fcl
@@ -249,27 +249,47 @@ physics: {
     }
 
     pmtmetricproducer: {
-   
-      AllowNTB: false
-      CAENInstanceLabels: [
-         "ContainerCAENV1730"
-      ]
-      CalculateBaseline: true
-      FindFlashInfo: true
-      FragIDs: [ 40960, 40961, 40962, 40963, 40964, 40965, 40966, 40967 ]
-      IncludeExtensions: true
-      SPECTDCDelay: 140
-      TimingType: 0
-      Verbose: 1
-      is_persistable: true
-      module_type: "PMTMetricProducer"
- 
-    }
-    pmtmetricproducer_bnbzero: @local::pmtmetricproducer
-    pmtmetricproducer_bnblight: @local::pmtmetricproducer
-    pmtmetricproducer_offbeamzero: @local::pmtmetricproducer
-    pmtmetricproducer_offbeamlight: @local::pmtmetricproducer
-    pmtmetricproducer_crossmuon: @local::pmtmetricproducer
+			module_type: "PMTMetricProducer" 
+			is_persistable: true 
+			IncludeExtensions: true 
+			Verbose: 1
+			StreamType: 1
+		}
+		pmtmetricbnbzero: {
+			module_type: "PMTMetricProducer" 
+			is_persistable: true 
+			IncludeExtensions: true 
+			Verbose: 1
+			StreamType: 1
+		}
+		pmtmetricbnblight: {
+			module_type: "PMTMetricProducer" 
+			is_persistable: true 
+			IncludeExtensions: true 
+			Verbose: 1
+			StreamType: 2
+		}
+		pmtmetricoffbeamzero: {
+			module_type: "PMTMetricProducer" 
+			is_persistable: true 
+			IncludeExtensions: true 
+			Verbose: 1
+			StreamType: 3
+		}
+		pmtmetricoffbeamlight: {
+			module_type: "PMTMetricProducer" 
+			is_persistable: true 
+			IncludeExtensions: true 
+			Verbose: 1
+			StreamType: 4
+		}
+		pmtmetriccrossingmuon: {
+			module_type: "PMTMetricProducer" 
+			is_persistable: true 
+			IncludeExtensions: true 
+			Verbose: 1
+			StreamType: 5
+		}
   }
   filters: {
     prescale50: {
@@ -323,11 +343,11 @@ physics: {
 
   softwaretrig: [prescale1, crttriggerproducer, pmtmetricproducer] 
   nustream: [bnbzerobiasfilter, crttriggerproducer, pmtmetricproducer, neutrinostream]
-  bnbzerobias: [bnbzerobiasfilter, crttriggerproducer, pmtmetricproducer_bnbzero] 
-  offbeamzerobias: [offbeamzerobiasfilter, crttriggerproducer, pmtmetricproducer_offbeamzero] 
-  bnblight: [bnblightfilter, crttriggerproducer, pmtmetricproducer_bnblight] 
-  offbeamlight: [offbeamlightfilter, crttriggerproducer, pmtmetricproducer_offbeamlight] 
-  crossingmuon: [crossingmuonfilter, crttriggerproducer, pmtmetricproducer_crossmuon] 
+  bnbzerobias: [bnbzerobiasfilter, crttriggerproducer, pmtmetricbnbzero] 
+  offbeamzerobias: [offbeamzerobiasfilter, crttriggerproducer, pmtmetricoffbeamzero] 
+  bnblight: [bnblightfilter, crttriggerproducer, pmtmetricbnblight] 
+  offbeamlight: [offbeamlightfilter, crttriggerproducer, pmtmetricoffbeamlight] 
+  crossingmuon: [crossingmuonfilter, crttriggerproducer, pmtmetriccrossingmuon] 
   #nscrossingmuon: [nscrossingmuonfilter, crttriggerproducer, pmtmetricproducer] 
   filterfail: ["!crossingmuonfilter", "!bnbzerobiasfilter", "!offbeamzerobiasfilter", "!bnblightfilter", "!offbeamlightfilter"] 
 


### PR DESCRIPTION
Create unique instances of the `pmtmetricproducer` module for different file streams. This will allow us to change `StreamType` (fcl parameter) for the different trigger_paths in the standard fcl. 

Goes along with https://github.com/SBNSoftware/sbndaq-artdaq/pull/178. 