### PR TITLE
Update to PMT 01 trigger logic + channel 15 thresholds

### DIFF
--- a/triggerLightScanA_2PE-/pmt01.fcl
+++ b/triggerLightScanA_2PE-/pmt01.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to try to prevent channel 15 (trigger copy) from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -38,21 +38,16 @@ daq.fragment_receiver.channelEnable14:   true
 daq.fragment_receiver.channelEnable15:   true
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Individual pair logic can be written to but the board reader doesn't have the code in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1 #I don't think this actually does anything?
 
-# Set self trigger logic
-# triggerLogic 0: AND, 1: ONLYA, 2: ONLYB, 3:OR
-# Exclusive for SBND, just for trig out
-# ICARUS: (should not interfere but) keep this parameter = 3
-daq.fragment_receiver.triggerLogic: 1
 
 daq.fragment_receiver.triggerPolarity: 1
 

--- a/triggerLightScanA_2PE-/pmt02.fcl
+++ b/triggerLightScanA_2PE-/pmt02.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to try to prevent channel 15 (trigger copy) from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Individual pair logic can be written to but the board reader doesn't have the code in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1 #I don't think this actually does anything?
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanA_2PE-/pmt03.fcl
+++ b/triggerLightScanA_2PE-/pmt03.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to try to prevent channel 15 (trigger copy) from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Individual pair logic can be written to but the board reader doesn't have the code in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1 #I don't think this actually does anything?
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanA_2PE-/pmt04.fcl
+++ b/triggerLightScanA_2PE-/pmt04.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to try to prevent channel 15 (trigger copy) from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Individual pair logic can be written to but the board reader doesn't have the code in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1 #I don't think this actually does anything?
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanA_2PE-/pmt05.fcl
+++ b/triggerLightScanA_2PE-/pmt05.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to try to prevent channel 15 (trigger copy) from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Individual pair logic can be written to but the board reader doesn't have the code in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1 #I don't think this actually does anything?
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanA_2PE-/pmt06.fcl
+++ b/triggerLightScanA_2PE-/pmt06.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to try to prevent channel 15 (trigger copy) from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Individual pair logic can be written to but the board reader doesn't have the code in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1 #I don't think this actually does anything?
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanA_2PE-/pmt07.fcl
+++ b/triggerLightScanA_2PE-/pmt07.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to try to prevent channel 15 (trigger copy) from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Individual pair logic can be written to but the board reader doesn't have the code in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1 #I don't think this actually does anything?
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanA_2PE-/pmt08.fcl
+++ b/triggerLightScanA_2PE-/pmt08.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to try to prevent channel 15 (trigger copy) from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Individual pair logic can be written to but the board reader doesn't have the code in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+daq.fragment_receiver.ovthValue: 1 #I don't think this actually does anything?
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanA_2PE-/pmt08.fcl
+++ b/triggerLightScanA_2PE-/pmt08.fcl
@@ -47,6 +47,6 @@ daq.fragment_receiver.channelEnable15:   true
 #daq.fragment_receiver.Pair_10_11_Logic: 3
 #daq.fragment_receiver.Pair_12_13_Logic: 3
 #daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1 #I don't think this actually does anything?
+#daq.fragment_receiver.ovthValue: 1 #I don't think this actually does anything?
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanB_2PE-/pmt01.fcl
+++ b/triggerLightScanB_2PE-/pmt01.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -38,21 +38,16 @@ daq.fragment_receiver.channelEnable14:   true
 daq.fragment_receiver.channelEnable15:   true
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
-# Set self trigger logic
-# triggerLogic 0: AND, 1: ONLYA, 2: ONLYB, 3:OR
-# Exclusive for SBND, just for trig out
-# ICARUS: (should not interfere but) keep this parameter = 3
-daq.fragment_receiver.triggerLogic: 1
 
 daq.fragment_receiver.triggerPolarity: 1
 

--- a/triggerLightScanB_2PE-/pmt02.fcl
+++ b/triggerLightScanB_2PE-/pmt02.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanB_2PE-/pmt03.fcl
+++ b/triggerLightScanB_2PE-/pmt03.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanB_2PE-/pmt04.fcl
+++ b/triggerLightScanB_2PE-/pmt04.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanB_2PE-/pmt05.fcl
+++ b/triggerLightScanB_2PE-/pmt05.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanB_2PE-/pmt06.fcl
+++ b/triggerLightScanB_2PE-/pmt06.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanB_2PE-/pmt07.fcl
+++ b/triggerLightScanB_2PE-/pmt07.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanB_2PE-/pmt08.fcl
+++ b/triggerLightScanB_2PE-/pmt08.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14225
 daq.fragment_receiver.triggerThreshold12: 14225
 daq.fragment_receiver.triggerThreshold13: 14225
 daq.fragment_receiver.triggerThreshold14: 14225
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanC_3PE-/pmt01.fcl
+++ b/triggerLightScanC_3PE-/pmt01.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -38,21 +38,15 @@ daq.fragment_receiver.channelEnable14:   true
 daq.fragment_receiver.channelEnable15:   true
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
-
-# Set self trigger logic
-# triggerLogic 0: AND, 1: ONLYA, 2: ONLYB, 3:OR
-# Exclusive for SBND, just for trig out
-# ICARUS: (should not interfere but) keep this parameter = 3
-daq.fragment_receiver.triggerLogic: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPolarity: 1
 

--- a/triggerLightScanC_3PE-/pmt02.fcl
+++ b/triggerLightScanC_3PE-/pmt02.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanC_3PE-/pmt03.fcl
+++ b/triggerLightScanC_3PE-/pmt03.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanC_3PE-/pmt04.fcl
+++ b/triggerLightScanC_3PE-/pmt04.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanC_3PE-/pmt05.fcl
+++ b/triggerLightScanC_3PE-/pmt05.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanC_3PE-/pmt06.fcl
+++ b/triggerLightScanC_3PE-/pmt06.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanC_3PE-/pmt07.fcl
+++ b/triggerLightScanC_3PE-/pmt07.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanC_3PE-/pmt08.fcl
+++ b/triggerLightScanC_3PE-/pmt08.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanD_3PE-/pmt01.fcl
+++ b/triggerLightScanD_3PE-/pmt01.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -38,21 +38,15 @@ daq.fragment_receiver.channelEnable14:   true
 daq.fragment_receiver.channelEnable15:   true
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
-
-# Set self trigger logic
-# triggerLogic 0: AND, 1: ONLYA, 2: ONLYB, 3:OR
-# Exclusive for SBND, just for trig out
-# ICARUS: (should not interfere but) keep this parameter = 3
-daq.fragment_receiver.triggerLogic: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPolarity: 1
 

--- a/triggerLightScanD_3PE-/pmt02.fcl
+++ b/triggerLightScanD_3PE-/pmt02.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanD_3PE-/pmt03.fcl
+++ b/triggerLightScanD_3PE-/pmt03.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanD_3PE-/pmt04.fcl
+++ b/triggerLightScanD_3PE-/pmt04.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanD_3PE-/pmt05.fcl
+++ b/triggerLightScanD_3PE-/pmt05.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanD_3PE-/pmt06.fcl
+++ b/triggerLightScanD_3PE-/pmt06.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanD_3PE-/pmt07.fcl
+++ b/triggerLightScanD_3PE-/pmt07.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanD_3PE-/pmt08.fcl
+++ b/triggerLightScanD_3PE-/pmt08.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanE_3PE-/pmt01.fcl
+++ b/triggerLightScanE_3PE-/pmt01.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from making trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -38,21 +38,15 @@ daq.fragment_receiver.channelEnable14:   true
 daq.fragment_receiver.channelEnable15:   true
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
-
-# Set self trigger logic
-# triggerLogic 0: AND, 1: ONLYA, 2: ONLYB, 3:OR
-# Exclusive for SBND, just for trig out
-# ICARUS: (should not interfere but) keep this parameter = 3
-daq.fragment_receiver.triggerLogic: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPolarity: 1
 

--- a/triggerLightScanE_3PE-/pmt02.fcl
+++ b/triggerLightScanE_3PE-/pmt02.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from making trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanE_3PE-/pmt03.fcl
+++ b/triggerLightScanE_3PE-/pmt03.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from making trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanE_3PE-/pmt04.fcl
+++ b/triggerLightScanE_3PE-/pmt04.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from making trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanE_3PE-/pmt05.fcl
+++ b/triggerLightScanE_3PE-/pmt05.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from making trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanE_3PE-/pmt06.fcl
+++ b/triggerLightScanE_3PE-/pmt06.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from making trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanE_3PE-/pmt07.fcl
+++ b/triggerLightScanE_3PE-/pmt07.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from making trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanE_3PE-/pmt08.fcl
+++ b/triggerLightScanE_3PE-/pmt08.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14212
 daq.fragment_receiver.triggerThreshold12: 14212
 daq.fragment_receiver.triggerThreshold13: 14212
 daq.fragment_receiver.triggerThreshold14: 14212
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from making trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanF_4PE-/pmt01.fcl
+++ b/triggerLightScanF_4PE-/pmt01.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -38,21 +38,15 @@ daq.fragment_receiver.channelEnable14:   true
 daq.fragment_receiver.channelEnable15:   true
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
-
-# Set self trigger logic
-# triggerLogic 0: AND, 1: ONLYA, 2: ONLYB, 3:OR
-# Exclusive for SBND, just for trig out
-# ICARUS: (should not interfere but) keep this parameter = 3
-daq.fragment_receiver.triggerLogic: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPolarity: 1
 

--- a/triggerLightScanF_4PE-/pmt02.fcl
+++ b/triggerLightScanF_4PE-/pmt02.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanF_4PE-/pmt03.fcl
+++ b/triggerLightScanF_4PE-/pmt03.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanF_4PE-/pmt04.fcl
+++ b/triggerLightScanF_4PE-/pmt04.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanF_4PE-/pmt05.fcl
+++ b/triggerLightScanF_4PE-/pmt05.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanF_4PE-/pmt06.fcl
+++ b/triggerLightScanF_4PE-/pmt06.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanF_4PE-/pmt07.fcl
+++ b/triggerLightScanF_4PE-/pmt07.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanF_4PE-/pmt08.fcl
+++ b/triggerLightScanF_4PE-/pmt08.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanG_4PE-/pmt01.fcl
+++ b/triggerLightScanG_4PE-/pmt01.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -38,21 +38,15 @@ daq.fragment_receiver.channelEnable14:   true
 daq.fragment_receiver.channelEnable15:   true
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
-
-# Set self trigger logic
-# triggerLogic 0: AND, 1: ONLYA, 2: ONLYB, 3:OR
-# Exclusive for SBND, just for trig out
-# ICARUS: (should not interfere but) keep this parameter = 3
-daq.fragment_receiver.triggerLogic: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPolarity: 1
 

--- a/triggerLightScanG_4PE-/pmt02.fcl
+++ b/triggerLightScanG_4PE-/pmt02.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanG_4PE-/pmt03.fcl
+++ b/triggerLightScanG_4PE-/pmt03.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanG_4PE-/pmt04.fcl
+++ b/triggerLightScanG_4PE-/pmt04.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanG_4PE-/pmt05.fcl
+++ b/triggerLightScanG_4PE-/pmt05.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanG_4PE-/pmt06.fcl
+++ b/triggerLightScanG_4PE-/pmt06.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanG_4PE-/pmt07.fcl
+++ b/triggerLightScanG_4PE-/pmt07.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanG_4PE-/pmt08.fcl
+++ b/triggerLightScanG_4PE-/pmt08.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14200
 daq.fragment_receiver.triggerThreshold12: 14200
 daq.fragment_receiver.triggerThreshold13: 14200
 daq.fragment_receiver.triggerThreshold14: 14200
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanH_5PE-/pmt01.fcl
+++ b/triggerLightScanH_5PE-/pmt01.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -38,21 +38,15 @@ daq.fragment_receiver.channelEnable14:   true
 daq.fragment_receiver.channelEnable15:   true
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
-
-# Set self trigger logic
-# triggerLogic 0: AND, 1: ONLYA, 2: ONLYB, 3:OR
-# Exclusive for SBND, just for trig out
-# ICARUS: (should not interfere but) keep this parameter = 3
-daq.fragment_receiver.triggerLogic: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPolarity: 1
 

--- a/triggerLightScanH_5PE-/pmt02.fcl
+++ b/triggerLightScanH_5PE-/pmt02.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanH_5PE-/pmt03.fcl
+++ b/triggerLightScanH_5PE-/pmt03.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanH_5PE-/pmt04.fcl
+++ b/triggerLightScanH_5PE-/pmt04.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanH_5PE-/pmt05.fcl
+++ b/triggerLightScanH_5PE-/pmt05.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanH_5PE-/pmt06.fcl
+++ b/triggerLightScanH_5PE-/pmt06.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanH_5PE-/pmt07.fcl
+++ b/triggerLightScanH_5PE-/pmt07.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanH_5PE-/pmt08.fcl
+++ b/triggerLightScanH_5PE-/pmt08.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered this to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanI_5PE-/pmt01.fcl
+++ b/triggerLightScanI_5PE-/pmt01.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -38,21 +38,15 @@ daq.fragment_receiver.channelEnable14:   true
 daq.fragment_receiver.channelEnable15:   true
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
-
-# Set self trigger logic
-# triggerLogic 0: AND, 1: ONLYA, 2: ONLYB, 3:OR
-# Exclusive for SBND, just for trig out
-# ICARUS: (should not interfere but) keep this parameter = 3
-daq.fragment_receiver.triggerLogic: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPolarity: 1
 

--- a/triggerLightScanI_5PE-/pmt02.fcl
+++ b/triggerLightScanI_5PE-/pmt02.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanI_5PE-/pmt03.fcl
+++ b/triggerLightScanI_5PE-/pmt03.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanI_5PE-/pmt04.fcl
+++ b/triggerLightScanI_5PE-/pmt04.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanI_5PE-/pmt05.fcl
+++ b/triggerLightScanI_5PE-/pmt05.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanI_5PE-/pmt06.fcl
+++ b/triggerLightScanI_5PE-/pmt06.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanI_5PE-/pmt07.fcl
+++ b/triggerLightScanI_5PE-/pmt07.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12

--- a/triggerLightScanI_5PE-/pmt08.fcl
+++ b/triggerLightScanI_5PE-/pmt08.fcl
@@ -17,7 +17,7 @@ daq.fragment_receiver.triggerThreshold11: 14187
 daq.fragment_receiver.triggerThreshold12: 14187
 daq.fragment_receiver.triggerThreshold13: 14187
 daq.fragment_receiver.triggerThreshold14: 14187
-daq.fragment_receiver.triggerThreshold15: 2000 #set this back to 2000 to prevent weird ghost MON out
+daq.fragment_receiver.triggerThreshold15: 500 #Lowered to 500 to prevent channel 15 from participating in trigger decisions
 
 #May just change waveform saving rather than actual outputs
 daq.fragment_receiver.channelEnable0:    true
@@ -39,14 +39,14 @@ daq.fragment_receiver.channelEnable15:   true
 
 
 #Per pair trigger logics for the MON output
-daq.fragment_receiver.Pair_0_1_Logic: 3
-daq.fragment_receiver.Pair_2_3_Logic: 3
-daq.fragment_receiver.Pair_4_5_Logic: 3
-daq.fragment_receiver.Pair_6_7_Logic: 3
-daq.fragment_receiver.Pair_8_9_Logic: 3
-daq.fragment_receiver.Pair_10_11_Logic: 3
-daq.fragment_receiver.Pair_12_13_Logic: 3
-daq.fragment_receiver.Pair_14_15_Logic: 1
-daq.fragment_receiver.ovthValue: 1
+#daq.fragment_receiver.Pair_0_1_Logic: 3 #Trigger logic is supported for individual channels but the board reader code isn't in place
+#daq.fragment_receiver.Pair_2_3_Logic: 3
+#daq.fragment_receiver.Pair_4_5_Logic: 3
+#daq.fragment_receiver.Pair_6_7_Logic: 3
+#daq.fragment_receiver.Pair_8_9_Logic: 3
+#daq.fragment_receiver.Pair_10_11_Logic: 3
+#daq.fragment_receiver.Pair_12_13_Logic: 3
+#daq.fragment_receiver.Pair_14_15_Logic: 1
+#daq.fragment_receiver.ovthValue: 1
 
 daq.fragment_receiver.triggerPulseWidth: 12


### PR DESCRIPTION
PMT01.fcl had ONLYA logic selected in all of our threshold scans. This effectively prevents 7 PMT from participating in trigger decisions and makes a region of the detector less able to trigger. 
This patch corrects that logic assignment, by making pmt01 pull logic from pmt_standard as is done for every other pmt.

Additionally, channel 15 (trigger copy in each CAEN) threshold was set just below the baseline of the channel at 2000 ADC. Given some baseline fluctuations its possible that channel 15 was contributing to trigger decisions. 
This patch lowers the trigger threshold to 500 ADC, which is far below baseline and should be robust against baseline fluctuations, effectively removing this accidental trigger contribution.
